### PR TITLE
Update Everforest theme

### DIFF
--- a/everforest.yaml
+++ b/everforest.yaml
@@ -1,18 +1,18 @@
-scheme: "EverForest"
-author: "sainnhe"
-base00: "2b3339"
-base01: "323c41"
-base02: "3a4248"
-base03: "868d80"
-base04: "a59572"
-base05: "d3c6aa"
-base06: "e9e8d2"
-base07: "fff9e8"
-base0D: "7fbbb3"
-base0E: "d699b6"
-base0C: "83c092"
-base0A: "dbbc7f"
-base09: "e69875"
-base0B: "a7c080"
-base08: "e67e80"
-base0F: "d699b6"
+scheme: "Everforest"
+author: "Sainnhe Park (https://github.com/sainnhe)"
+base00: "2f383e" # bg0,       palette1 dark (medium)
+base01: "374247" # bg1,       palette1 dark (medium)
+base02: "4a555b" # bg3,       palette1 dark (medium)
+base03: "859289" # grey1,     palette2 dark
+base04: "9da9a0" # grey2,     palette2 dark
+base05: "d3c6aa" # fg,        palette2 dark
+base06: "e4e1cd" # bg3,       palette1 light (medium)
+base07: "fdf6e3" # bg0,       palette1 light (medium)
+base08: "7fbbb3" # blue,      palette2 dark
+base09: "d699b6" # purple,    palette2 dark
+base0A: "dbbc7f" # yellow,    palette2 dark
+base0B: "83c092" # aqua,      palette2 dark
+base0C: "e69875" # orange,    palette2 dark
+base0D: "a7c080" # green,     palette2 dark
+base0E: "e67e80" # red,       palette2 dark
+base0F: "eaedc8" # bg_visual, palette1 dark (medium)


### PR DESCRIPTION
Fixes #13 

- Update outdated colors based on Everforest's default _dark medium_ variant.
- Document each color based on its name in the Everforest palette ([palette1](https://github.com/sainnhe/everforest/blob/866bf1a762dfd51a980f2deb9e7c6f23b4d984e3/autoload/everforest.vim#L62-L77), [palette2](https://github.com/sainnhe/everforest/blob/866bf1a762dfd51a980f2deb9e7c6f23b4d984e3/autoload/everforest.vim#L123-L140))

Result:

![b16-everforest](https://user-images.githubusercontent.com/3299086/185784960-ff434aea-79ff-4d61-ab2e-06c966ebab73.jpg)

---

**IMPORTANT NOTICE:**

The order of the colors doesn't match the typical [base16 color order](https://chriskempson.com/projects/base16/#styling-guidelines). This is a deliberate decision to remain as close as possible to the semantic meaning of the Everforest colors, where functions are green, keywords red, strings aqua, constants purple, etc.

Base16 doesn't mandate that themes adopt red for keywords, orange for constants, etc. In fact, there are [multiple base16 themes](https://base16-project.github.io/base16-gallery/) which color order doesn't match the default theme. However, I also know that the original base16 spec [has a few flaws](https://github.com/base16-project/home/issues/52#issuecomment-1177305079) — such as "variables AND diff deleted MUST always be the same color" — so if you want me to stay more conservative regarding base16 semantics, and swap the colors like one of the two alternatives below, just let me know!

_alt1_ (strings and functions retain the Everforest semantics)

![b16-everforest-alt1](https://user-images.githubusercontent.com/3299086/185785593-bc1709fa-85ae-42f2-9ded-ed8e5ce12238.jpg)

_alt2_ (nothing retains the Everforest semantics)

![b16-everforest-alt1](https://user-images.githubusercontent.com/3299086/185785694-9e85b714-d753-4b37-8fc2-e508562c45ce.jpg)